### PR TITLE
(Changed) Upgrade to PHP 8.3 with Code Refactoring and Test Method Consistency Improvements

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,10 +9,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up php 8.2
+      - name: Set up php 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.3"
           extensions: mbstring, xml, zip, pdo_mysql, xhprof
 
       - name: Install dependencies

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.2", "8.3", "8.4"]
+        php-versions: ["8.3", "8.4"]
 
     steps:
       # This step checks out a copy of your repository.

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -54,8 +54,8 @@ return [
     //
     // Note that the **only** effect of choosing `'5.6'` is to infer that functions removed in php 7.0 exist.
     // (See `backward_compatibility_checks` for additional options)
-    // Automatically inferred from composer.json requirement for "php" of "^8.2"
-    'target_php_version' => '8.2',
+    // Automatically inferred from composer.json requirement for "php" of "^8.3"
+    'target_php_version' => '8.3',
 
     // If enabled, missing properties will be created when
     // they are first seen. If false, we'll report an

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ applying the Luhn algorithm for checksum digit validation.
 
 ## System Requirements
 
-- PHP version 8.2 or higher.
+- PHP version 8.3 or higher.
 
 ## Installation
 
@@ -116,7 +116,7 @@ criteria aren't met (e.g., incorrect citizenship status digit).
 Encountering issues? Here are solutions to some common problems:
 
 - **Problem:** Difficulty in installing the package via Composer.
-    - **Solution:** Verify your PHP version is at least 8.2 and that Composer is correctly installed on your system. For
+    - **Solution:** Verify your PHP version is at least 8.3 and that Composer is correctly installed on your system. For
       persistent issues, try clearing Composer's cache with `composer clear-cache` and attempt the installation again.
 
 - **Problem:** Validation consistently results in `false`.

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=8.3",
-    "marjovanlier/stringmanipulation": "^1.0.84"
+    "marjovanlier/stringmanipulation": "^2.0.1"
   },
   "require-dev": {
     "enlightn/security-checker": ">=2.0.0",
@@ -52,7 +52,7 @@
     "phpstan/extension-installer": ">=1.4.3",
     "phpstan/phpstan": ">=2.1.4",
     "phpstan/phpstan-strict-rules": ">=2.0.3",
-    "phpunit/phpunit": ">=11.0.4|>=12.0.0",
+    "phpunit/phpunit": ">=12.0.0",
     "psalm/plugin-phpunit": ">=0.19.2",
     "rector/rector": ">=2.0.9",
     "roave/security-advisories": "dev-latest",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "php": ">=8.2",
+    "php": ">=8.3",
     "marjovanlier/stringmanipulation": "^1.0.84"
   },
   "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 parameters:
     level: max
-    phpVersion: 80200
+    phpVersion: 80300
     treatPhpDocTypesAsCertain: false
     tipsOfTheDay: false
     reportWrongPhpDocTypeInVarTag: true

--- a/rector.php
+++ b/rector.php
@@ -43,17 +43,17 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(SeparateMultiUseImportsRector::class);
     $rectorConfig->rule(SplitDoubleAssignRector::class);
 
-    $rectorConfig->phpVersion(PhpVersion::PHP_82);
+    $rectorConfig->phpVersion(PhpVersion::PHP_83);
 
     // define sets of rules
     $rectorConfig->sets(
         [
-            LevelSetList::UP_TO_PHP_82,
+            LevelSetList::UP_TO_PHP_83,
             SetList::CODE_QUALITY,
             SetList::CODING_STYLE,
             SetList::DEAD_CODE,
             SetList::EARLY_RETURN,
-            SetList::PHP_82,
+            SetList::PHP_83,
             SetList::TYPE_DECLARATION,
             SetList::NAMING,
             SetList::PRIVATIZATION,

--- a/src/SouthAfricanIDValidator.php
+++ b/src/SouthAfricanIDValidator.php
@@ -39,7 +39,7 @@ class SouthAfricanIDValidator
      *
      * @see self::sanitizeNumber
      */
-    private const NON_DIGIT_REGEX = '#\D#';
+    private const string NON_DIGIT_REGEX = '#\D#';
 
 
     /**
@@ -83,9 +83,8 @@ class SouthAfricanIDValidator
      *
      * @param string $number The South African ID number to validate.
      *
-     * @return null|bool True if the ID number is valid, false if it's not, and null if specific criteria aren't met.
-     *
-     * @see https://en.wikipedia.org/wiki/South_African_identity_card
+     * @return bool|null True if the ID number is valid, false if it's not, and null if specific criteria aren't met.
+     * @see    https://en.wikipedia.org/wiki/South_African_identity_card
      */
     public static function luhnIDValidate(string $number): ?bool
     {
@@ -93,7 +92,7 @@ class SouthAfricanIDValidator
         $number = self::sanitizeNumber($number);
 
         // If the sanitized number isn't exactly 13 characters long, return false
-        if (strlen($number) !== 13) {
+        if (\strlen($number) !== 13) {
             return false;
         }
 
@@ -129,14 +128,13 @@ class SouthAfricanIDValidator
      * @param string $date The date part of the ID, in YYMMDD format.
      *
      * @return bool True if the date is valid for any specified century, false otherwise.
-     *
-     * @see self::isValidDateFor1800sOr1900s
-     * @see self::isValidDateFor2000s
+     * @see    self::isValidDateFor1800sOr1900s
+     * @see    self::isValidDateFor2000s
      */
     public static function isValidIDDate(string $date): bool
     {
         // If the date string isn't 6 characters long, return false
-        if (strlen($date) !== 6) {
+        if (\strlen($date) !== 6) {
             return false;
         }
 
@@ -166,12 +164,12 @@ class SouthAfricanIDValidator
     private static function sanitizeNumber(string $number): string
     {
         // If the input is already all digits, return it as is
-        if (ctype_digit($number)) {
+        if (\ctype_digit($number)) {
             return $number;
         }
 
         // Replace all non-digit characters with an empty string, coalesce null to an empty string if needed
-        return (preg_replace(self::NON_DIGIT_REGEX, '', $number) ?? '');
+        return (\preg_replace(self::NON_DIGIT_REGEX, '', $number) ?? '');
     }
 
 
@@ -193,7 +191,7 @@ class SouthAfricanIDValidator
     private static function isValidEleventhCharacter(string $number): bool
     {
         // Return false if the ID number is shorter than 11 characters
-        if (strlen($number) < 11) {
+        if (\strlen($number) < 11) {
             return false;
         }
 
@@ -201,7 +199,7 @@ class SouthAfricanIDValidator
         $eleventhCharacter = $number[10];
 
         // Return the result of the check
-        return in_array($eleventhCharacter, ['0', '1', '2'], true);
+        return \in_array($eleventhCharacter, ['0', '1', '2'], true);
     }
 
 
@@ -216,13 +214,12 @@ class SouthAfricanIDValidator
      * @param string $number The South African ID number to check.
      *
      * @return bool True if the date component is valid, false otherwise.
-     *
-     * @see self::isValidIDDate
+     * @see    self::isValidIDDate
      */
     private static function isValidDateInID(string $number): bool
     {
         // Extract the date part and validate it
-        $ymd = substr($number, 0, 6);
+        $ymd = \substr($number, 0, 6);
 
         // Return the result of the date validation
         return self::isValidIDDate($ymd);
@@ -242,14 +239,13 @@ class SouthAfricanIDValidator
      *
      * @param string $date A 6-character date string for an 18th or 19th-century date.
      *
-     * @return bool True if it's a valid date in either century, false otherwise.
-     *
+     * @return         bool True if it's a valid date in either century, false otherwise.
      * @psalm-suppress UnusedMethod
      */
     private static function isValidDateFor1800sOr1900s(string $date): bool
     {
         // Return false if the date string isn't exactly 6 characters long
-        if (strlen($date) !== 6) {
+        if (\strlen($date) !== 6) {
             return false;
         }
 
@@ -269,14 +265,13 @@ class SouthAfricanIDValidator
      *
      * @param string $date A 6-character date string for a 20th-century date.
      *
-     * @return bool True if it's a valid 20th-century date, false otherwise.
-     *
+     * @return         bool True if it's a valid 20th-century date, false otherwise.
      * @psalm-suppress UnusedMethod
      */
     private static function isValidDateFor2000s(string $date): bool
     {
         // Return false if the date string isn't exactly 6 characters long
-        if (strlen($date) !== 6) {
+        if (\strlen($date) !== 6) {
             return false;
         }
 
@@ -296,13 +291,12 @@ class SouthAfricanIDValidator
      * @param string $number The number to validate.
      *
      * @return bool True if the number is valid, according to the Luhn algorithm, false otherwise.
-     *
-     * @see https://en.wikipedia.org/wiki/Luhn_algorithm
+     * @see    https://en.wikipedia.org/wiki/Luhn_algorithm
      */
     private static function isValidLuhnChecksum(string $number): bool
     {
         // Check for non-numeric characters
-        if (!ctype_digit($number)) {
+        if (!\ctype_digit($number)) {
             return false;
         }
 
@@ -311,7 +305,7 @@ class SouthAfricanIDValidator
         $double = false;
 
         // Iterate over the number from rightmost to leftmost
-        for ($i = (strlen($number) - 1); $i >= 0; --$i) {
+        for ($i = (\strlen($number) - 1); $i >= 0; --$i) {
             /**
              * Explicit casting.
              *

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -16,7 +16,7 @@ gha_enabled: True
 # Example:
 #
 # description: This field should briefly describe the coding practices and unique aspects of your project. Use it to inform contributors about any specific standards or requirements.
-description: 'The SouthAfricanIDValidator is a PHP 8.2 package with its codebase located in the src directory. It adheres to the PER Coding Style 2.0, enhancing the PSR-12 standard. This information is crucial for guiding contributors in making compliant contributions.'
+description: 'The SouthAfricanIDValidator is a PHP 8.3 package with its codebase located in the src directory. It adheres to the PER Coding Style 2.0, enhancing the PSR-12 standard. This information is crucial for guiding contributors in making compliant contributions.'
 
 # This sets whether to create pull requests as drafts. If this is set to True, then all pull requests will be created as drafts and GitHub Actions will not be triggered.
 draft: False

--- a/tests/Unit/IsValidDateInIDTest.php
+++ b/tests/Unit/IsValidDateInIDTest.php
@@ -12,41 +12,18 @@ use UnexpectedValueException;
 
 /**
  * @internal
- *
- * @covers \MarjovanLier\SouthAfricanIDValidator\SouthAfricanIDValidator::isValidDateInID
+ * @covers   \MarjovanLier\SouthAfricanIDValidator\SouthAfricanIDValidator::isValidDateInID
  */
 final class IsValidDateInIDTest extends TestCase
 {
     /**
      * @throws ReflectionException
      */
-    public function testValidYYMMDDDate(): void
+    public function testValidYymmddDate(): void
     {
         self::assertTrue($this->invokePrivateStaticMethod(['870110xxxxxx']));
         self::assertTrue($this->invokePrivateStaticMethod(['220831xxxxxx']));
     }
-
-
-    /**
-     * @throws ReflectionException
-     */
-    public function testInvalidYYMMDDDate(): void
-    {
-        self::assertFalse($this->invokePrivateStaticMethod(['871332xxxxxx']), 'Invalid day (32)');
-        self::assertFalse($this->invokePrivateStaticMethod(['871313xxxxxx']), 'Invalid month (13)');
-        self::assertFalse($this->invokePrivateStaticMethod(['87-01-10xxxxx']), 'Invalid characters');
-        self::assertFalse($this->invokePrivateStaticMethod(['xyz123xxxxx']), 'Invalid characters');
-    }
-
-
-    /**
-     * @throws ReflectionException
-     */
-    public function testInvalidDateFormat(): void
-    {
-        self::assertFalse($this->invokePrivateStaticMethod(['87101xxxxxx']), 'Invalid length (too short)');
-    }
-
 
     /**
      * @param array<int, string> $parameters
@@ -58,8 +35,7 @@ final class IsValidDateInIDTest extends TestCase
         $reflectionMethod = (new ReflectionClass(SouthAfricanIDValidator::class))->getMethod('isValidDateInID');
 
         /**
-         * @noinspection PhpExpressionResultUnusedInspection
-         *
+         * @noinspection   PhpExpressionResultUnusedInspection
          * @psalm-suppress UnusedMethodCall
          */
         $reflectionMethod->setAccessible(true);
@@ -72,5 +48,24 @@ final class IsValidDateInIDTest extends TestCase
         }
 
         return $result;
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testInvalidYymmddDate(): void
+    {
+        self::assertFalse($this->invokePrivateStaticMethod(['871332xxxxxx']), 'Invalid day (32)');
+        self::assertFalse($this->invokePrivateStaticMethod(['871313xxxxxx']), 'Invalid month (13)');
+        self::assertFalse($this->invokePrivateStaticMethod(['87-01-10xxxxx']), 'Invalid characters');
+        self::assertFalse($this->invokePrivateStaticMethod(['xyz123xxxxx']), 'Invalid characters');
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testInvalidDateFormat(): void
+    {
+        self::assertFalse($this->invokePrivateStaticMethod(['87101xxxxxx']), 'Invalid length (too short)');
     }
 }

--- a/tests/Unit/IsValidEleventhCharacterTest.php
+++ b/tests/Unit/IsValidEleventhCharacterTest.php
@@ -16,10 +16,7 @@ use ReflectionException;
  */
 final class IsValidEleventhCharacterTest extends TestCase
 {
-    /**
-     * @var string[]
-     */
-    private const INVALID_CHARACTERS = [
+    private const array INVALID_CHARACTERS = [
         '3',
         '4',
         '5',
@@ -32,10 +29,7 @@ final class IsValidEleventhCharacterTest extends TestCase
         'Z',
     ];
 
-    /**
-     * @var string
-     */
-    private const NUMBER = '123456789';
+    private const string NUMBER = '123456789';
 
 
     public function testValidEleventhCharacter(): void
@@ -43,10 +37,8 @@ final class IsValidEleventhCharacterTest extends TestCase
         foreach (['0', '1', '2'] as $char) {
             $number = '1234567890' . $char;
 
-            /**
-             * @var bool $result
-             */
             $result = $this->invokeMethod(new SouthAfricanIDValidator(), 'isValidEleventhCharacter', [$number]);
+            assert(is_bool($result));
             self::assertTrue($result, sprintf('Expected %s to be a valid eleventh character', $char));
         }
     }
@@ -60,7 +52,6 @@ final class IsValidEleventhCharacterTest extends TestCase
      * @param array<int, string> $parameters Array of parameters to pass into method.
      *
      * @return mixed Method return.
-     *
      * @throws ReflectionException
      */
     public function invokeMethod(object $object, string $methodName, array $parameters = []): mixed
@@ -68,8 +59,7 @@ final class IsValidEleventhCharacterTest extends TestCase
         $reflectionMethod = (new ReflectionClass($object::class))->getMethod($methodName);
 
         /**
-         * @noinspection PhpExpressionResultUnusedInspection
-         *
+         * @noinspection   PhpExpressionResultUnusedInspection
          * @psalm-suppress UnusedMethodCall
          */
         $reflectionMethod->setAccessible(true);
@@ -81,31 +71,25 @@ final class IsValidEleventhCharacterTest extends TestCase
     public function testInvalidEleventhCharacter(): void
     {
         foreach (self::INVALID_CHARACTERS as $char) {
-            /**
-             * @var bool $result
-             */
             $result = $this->invokeMethod(new SouthAfricanIDValidator(), 'isValidEleventhCharacter', [self::NUMBER]);
+            assert(is_bool($result));
             self::assertFalse($result, sprintf('Expected %s to be an invalid eleventh character', $char));
         }
     }
 
 
-    public function testShortIDNumber(): void
+    public function testShortIdNumber(): void
     {
-        /**
-         * @var bool $result
-         */
         $result = $this->invokeMethod(new SouthAfricanIDValidator(), 'isValidEleventhCharacter', ['123456789']);
+        assert(is_bool($result));
         self::assertFalse($result, 'Expected short ID number to be invalid');
     }
 
 
     public function testDifferentiateBetweenTenthAndEleventhCharacter(): void
     {
-        /**
-         * @var bool $result
-         */
         $result = $this->invokeMethod(new SouthAfricanIDValidator(), 'isValidEleventhCharacter', ['123456789X0']);
+        assert(is_bool($result));
         self::assertTrue($result);
     }
 }

--- a/tests/Unit/IsValidIDDateTest.php
+++ b/tests/Unit/IsValidIDDateTest.php
@@ -64,7 +64,7 @@ final class IsValidIDDateTest extends TestCase
      * @dataProvider provideValidIDDates
      */
     #[DataProvider('provideValidIDDates')]
-    public function testValidIDDates(string $date): void
+    public function testValidIdDates(string $date): void
     {
         self::assertTrue(SouthAfricanIDValidator::isValidIDDate($date));
     }
@@ -74,7 +74,7 @@ final class IsValidIDDateTest extends TestCase
      * @dataProvider provideInvalidIDDates
      */
     #[DataProvider('provideInvalidIDDates')]
-    public function testInvalidIDDates(string $date): void
+    public function testInvalidIdDates(string $date): void
     {
         self::assertFalse(SouthAfricanIDValidator::isValidIDDate($date));
     }

--- a/tests/Unit/IsValidLuhnChecksumTest.php
+++ b/tests/Unit/IsValidLuhnChecksumTest.php
@@ -187,6 +187,25 @@ final class IsValidLuhnChecksumTest extends TestCase
         self::assertTrue($result);
     }
 
+    /**
+     * This method returns a ReflectionMethod instance of the private method 'isValidLuhnChecksum' in the
+     * SouthAfricanIDValidator class.
+     *
+     * @throws ReflectionException
+     */
+    private function getPrivateMethod(): ReflectionMethod
+    {
+        $reflectionMethod = (new ReflectionClass(SouthAfricanIDValidator::class))->getMethod('isValidLuhnChecksum');
+
+        /**
+         * @noinspection PhpExpressionResultUnusedInspection
+         *
+         * @psalm-suppress UnusedMethodCall
+         */
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod;
+    }
 
     /**
      * This method tests the Luhn validation method with invalid Luhn numbers.
@@ -201,7 +220,6 @@ final class IsValidLuhnChecksumTest extends TestCase
         $result = $this->getPrivateMethod()->invokeArgs(new SouthAfricanIDValidator(), [$number]);
         self::assertFalse($result);
     }
-
 
     /**
      * This method tests the Luhn validation method with valid Luhn numbers and checks for integer casting issues.
@@ -221,7 +239,6 @@ final class IsValidLuhnChecksumTest extends TestCase
         );
     }
 
-
     /**
      * This method tests the Luhn validation method with a number where not casting to int would fail the Luhn check
      *      due to string concatenation instead of arithmetic addition.
@@ -236,7 +253,6 @@ final class IsValidLuhnChecksumTest extends TestCase
         $result = $this->getPrivateMethod()->invokeArgs(new SouthAfricanIDValidator(), [$number]);
         self::assertTrue($result, 'Failed to handle string digits as integers correctly.');
     }
-
 
     /**
      * This method tests the Luhn validation method with a dataset of numbers and their expected Luhn validation
@@ -255,26 +271,5 @@ final class IsValidLuhnChecksumTest extends TestCase
             $result,
             sprintf("Test case '%s' failed. Expected '%s'.", $description, $expectedOutcome ? 'true' : 'false'),
         );
-    }
-
-
-    /**
-     * This method returns a ReflectionMethod instance of the private method 'isValidLuhnChecksum' in the
-     * SouthAfricanIDValidator class.
-     *
-     * @throws ReflectionException
-     */
-    private function getPrivateMethod(): ReflectionMethod
-    {
-        $reflectionMethod = (new ReflectionClass(SouthAfricanIDValidator::class))->getMethod('isValidLuhnChecksum');
-
-        /**
-         * @noinspection PhpExpressionResultUnusedInspection
-         *
-         * @psalm-suppress UnusedMethodCall
-         */
-        $reflectionMethod->setAccessible(true);
-
-        return $reflectionMethod;
     }
 }

--- a/tests/Unit/LuhnIDValidateTest.php
+++ b/tests/Unit/LuhnIDValidateTest.php
@@ -15,10 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class LuhnIDValidateTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private const ALTERED_ID_NUMBER = '8701105022186';
+    private const string ALTERED_ID_NUMBER = '8701105022186';
 
 
     /**
@@ -96,7 +93,7 @@ final class LuhnIDValidateTest extends TestCase
      * @dataProvider provideValidIDNumbers
      */
     #[DataProvider('provideValidIDNumbers')]
-    public function testValidIDNumbers(string $idNumber): void
+    public function testValidIdNumbers(string $idNumber): void
     {
         self::assertTrue(SouthAfricanIDValidator::luhnIDValidate($idNumber));
     }
@@ -106,7 +103,7 @@ final class LuhnIDValidateTest extends TestCase
      * @dataProvider provideInvalidIDNumbers
      */
     #[DataProvider('provideInvalidIDNumbers')]
-    public function testInvalidIDNumbers(string $idNumber): void
+    public function testInvalidIdNumbers(string $idNumber): void
     {
         self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumber));
     }
@@ -116,7 +113,7 @@ final class LuhnIDValidateTest extends TestCase
      * @dataProvider provideInvalidFormatIDNumbers
      */
     #[DataProvider('provideInvalidFormatIDNumbers')]
-    public function testInvalidFormatIDNumbers(string $idNumber): void
+    public function testInvalidFormatIdNumbers(string $idNumber): void
     {
         self::assertNull(SouthAfricanIDValidator::luhnIDValidate($idNumber));
     }
@@ -147,104 +144,6 @@ final class LuhnIDValidateTest extends TestCase
         self::assertEquals($expected, SouthAfricanIDValidator::luhnIDValidate($idNumber));
     }
 
-
-    /**
-     * Tests if string number inputs are correctly validated.
-     */
-    public function testStringNumberInput(): void
-    {
-        $idNumber = '8701105800085';
-        self::assertTrue(SouthAfricanIDValidator::luhnIDValidate($idNumber));
-    }
-
-
-    /**
-     * Tests if non-integer values in the ID number are correctly invalidated.
-     */
-    public function testNonIntegerValues(): void
-    {
-        $idNumber = '87011X5022086';
-        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumber));
-    }
-
-
-    /**
-     * Tests the parity logic of the Luhn algorithm.
-     */
-    public function testParityLogic(): void
-    {
-        $idNumber = '8701105800085';
-        self::assertTrue(SouthAfricanIDValidator::luhnIDValidate($idNumber));
-
-        $idNumberAltered = '8701105022186';
-        // Try to change a number that would affect parity calculation.
-        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumberAltered));
-    }
-
-
-    /**
-     * Tests if ID numbers containing the digit five are correctly validated.
-     */
-    public function testNumberHavingFive(): void
-    {
-        $idNumber = '8701155022086';
-        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumber));
-    }
-
-
-    /**
-     * Tests if the Luhn checksum logic works correctly when digits are incremented or decremented.
-     */
-    public function testTotalIncrementDecrementLogic(): void
-    {
-        $idNumber = '8701105800085';
-        self::assertTrue(SouthAfricanIDValidator::luhnIDValidate($idNumber));
-
-        $idNumberAltered = '8701105022087';
-        // Altering the last digit should make the ID invalid.
-        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumberAltered));
-    }
-
-
-    /**
-     * Tests the parity logic of the Luhn algorithm.
-     */
-    public function testLuhnParityLogic(): void
-    {
-        $idNumber = '8701105025086';
-        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumber));
-    }
-
-
-    /**
-     * Tests if the Luhn algorithm correctly splits double digits.
-     */
-    public function testLuhnDoubleDigitSplit(): void
-    {
-        $idNumber = '8701105026086';
-        // The 10th character when doubled becomes 12, which should be treated as 1 + 2
-        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumber));
-    }
-
-
-    /**
-     * Tests if altering a digit in the ID number makes it invalid.
-     */
-    public function testAlterationMakesIDInvalid(): void
-    {
-        // Altering a single digit to make it invalid
-        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate(self::ALTERED_ID_NUMBER));
-    }
-
-
-    public function testLuhnIDValidateWithMod5True(): void
-    {
-        self::assertTrue(SouthAfricanIDValidator::luhnIDValidate('8809260027087'));
-        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate('6804045679085'));
-        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate('8806087993185'));
-    }
-
-
     private function computeLuhnChecksum(string $number): bool
     {
         $parity = (strlen($number) % 2);
@@ -266,5 +165,93 @@ final class LuhnIDValidateTest extends TestCase
         }
 
         return ($total % 10) === 0;
+    }
+
+    /**
+     * Tests if string number inputs are correctly validated.
+     */
+    public function testStringNumberInput(): void
+    {
+        $idNumber = '8701105800085';
+        self::assertTrue(SouthAfricanIDValidator::luhnIDValidate($idNumber));
+    }
+
+    /**
+     * Tests if non-integer values in the ID number are correctly invalidated.
+     */
+    public function testNonIntegerValues(): void
+    {
+        $idNumber = '87011X5022086';
+        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumber));
+    }
+
+    /**
+     * Tests the parity logic of the Luhn algorithm.
+     */
+    public function testParityLogic(): void
+    {
+        $idNumber = '8701105800085';
+        self::assertTrue(SouthAfricanIDValidator::luhnIDValidate($idNumber));
+
+        $idNumberAltered = '8701105022186';
+        // Try to change a number that would affect parity calculation.
+        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumberAltered));
+    }
+
+    /**
+     * Tests if ID numbers containing the digit five are correctly validated.
+     */
+    public function testNumberHavingFive(): void
+    {
+        $idNumber = '8701155022086';
+        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumber));
+    }
+
+    /**
+     * Tests if the Luhn checksum logic works correctly when digits are incremented or decremented.
+     */
+    public function testTotalIncrementDecrementLogic(): void
+    {
+        $idNumber = '8701105800085';
+        self::assertTrue(SouthAfricanIDValidator::luhnIDValidate($idNumber));
+
+        $idNumberAltered = '8701105022087';
+        // Altering the last digit should make the ID invalid.
+        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumberAltered));
+    }
+
+    /**
+     * Tests the parity logic of the Luhn algorithm.
+     */
+    public function testLuhnParityLogic(): void
+    {
+        $idNumber = '8701105025086';
+        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumber));
+    }
+
+    /**
+     * Tests if the Luhn algorithm correctly splits double digits.
+     */
+    public function testLuhnDoubleDigitSplit(): void
+    {
+        $idNumber = '8701105026086';
+        // The 10th character when doubled becomes 12, which should be treated as 1 + 2
+        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate($idNumber));
+    }
+
+    /**
+     * Tests if altering a digit in the ID number makes it invalid.
+     */
+    public function testAlterationMakesIdInvalid(): void
+    {
+        // Altering a single digit to make it invalid
+        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate(self::ALTERED_ID_NUMBER));
+    }
+
+    public function testLuhnIdValidateWithMod5True(): void
+    {
+        self::assertTrue(SouthAfricanIDValidator::luhnIDValidate('8809260027087'));
+        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate('6804045679085'));
+        self::assertFalse(SouthAfricanIDValidator::luhnIDValidate('8806087993185'));
     }
 }

--- a/tests/Unit/SanitizeNumberTest.php
+++ b/tests/Unit/SanitizeNumberTest.php
@@ -52,8 +52,7 @@ final class SanitizeNumberTest extends TestCase
         $reflectionMethod = (new ReflectionClass($object::class))->getMethod($methodName);
 
         /**
-         * @noinspection PhpExpressionResultUnusedInspection
-         *
+         * @noinspection   PhpExpressionResultUnusedInspection
          * @psalm-suppress UnusedMethodCall
          */
         $reflectionMethod->setAccessible(true);


### PR DESCRIPTION
## Summary

This merge request updates the codebase to require PHP 8.3, streamlines test method naming conventions, and reorganises the test suite for increased clarity. It also includes dependency updates in `composer.json` to ensure compatibility with PHP 8.3 and aligns references in supporting files (such as Rector, PHPStan, and GitHub workflows).

### Context and Background

Moving from PHP 8.2 to PHP 8.3 allows us to leverage new language features, improve overall code quality, and remain consistent with modern development practices. Additionally, our test structure and naming standards required consistency to enhance maintainability. Links to relevant documentation and discussions:

- [Conventional Commits (ADR-1)](https://www.conventionalcommits.org/en/v1.0.0/)
- [Keep a Changelog (ADR-6)](https://keepachangelog.com/en/1.1.0/)

### Problem Description

The existing codebase constrained our development workflow to PHP 8.2, limiting the adoption of newer language improvements. Furthermore, test method names and file organisation were inconsistent across the project, complicating maintenance and readability.

### Solution Description

1. **PHP Version Bump**: Updated `composer.json`, CI workflows, PHPStan, Rector, and documentation to require and support PHP 8.3.
2. **Test Refactoring**: Renamed test methods to follow a consistent camelCase pattern (e.g., `testInvalidIdNumbers` instead of `testInvalidIDNumbers`).
3. **Dependency Updates**: Incremented versions of required libraries, including `marjovanlier/stringmanipulation`, to align with PHP 8.3.
4. **Namespace Function Calls**: Prefixed PHP built-in functions (e.g.,`\strlen`, `\ctype_digit`) to potentially improve performance and clarity.
5. **Documentation and Config**: Revised README, sweep.yaml, and other config files to reflect the new PHP version requirement and coding standards.

### List of Changes

- **refactor**: Reorganise test files and rename methods for clarity
- **build**: Update CI configurations and Rector/PHPStan to target PHP 8.3
- **build**: Modify composer.json to require PHP 8.3 and bump library versions
- **docs**: Revise README.md to mention PHP 8.3 as the new minimum
- **style**: Consistently prefix PHP built-ins with `\` for clarity and performance
