### PR TITLE
ci(workflow): Fix OSV-Scanner permissions and update to v2.2.3

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -22,6 +22,8 @@ on:
     branches: [ "main" ]
 
 permissions:
+  # Required for reusable workflows
+  actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write
   # Read commit contents
@@ -30,7 +32,7 @@ permissions:
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9d4732e8b9db0915df9608123133640b58bb6750" # v2.2.2
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@e92b5d07338d4f0ba0981dffed17c48976ca4730" # v2.2.3
     with:
       # Example of specifying custom arguments
       scan-args: |-
@@ -39,7 +41,7 @@ jobs:
         ./
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9d4732e8b9db0915df9608123133640b58bb6750" # v2.2.2
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@e92b5d07338d4f0ba0981dffed17c48976ca4730" # v2.2.3
     with:
       # Example of specifying custom arguments
       scan-args: |-


### PR DESCRIPTION
### **User description**
## Summary

- Add missing `actions: read` permission required by reusable workflows
- Update OSV-Scanner action from v2.2.2 to v2.2.3

## Problem

The OSV-Scanner workflow was failing with the error:
```
The workflow is requesting 'actions: read', but is only allowed 'actions: none'.
```

This occurred because the reusable OSV-Scanner workflows require the `actions: read` permission, which was not granted in the permissions block.

## Solution

1. **Added `actions: read` permission** — Required for reusable workflows to function properly
2. **Updated to v2.2.3** — Latest version includes bug fixes and improvements

## Changes

- `.github/workflows/osv-scanner.yml`:
  - Added `actions: read` to permissions block
  - Updated `scan-scheduled` job to v2.2.3 (`e92b5d07338d4f0ba0981dffed17c48976ca4730`)
  - Updated `scan-pr` job to v2.2.3 (`e92b5d07338d4f0ba0981dffed17c48976ca4730`)

## Test Plan

- [ ] Workflow validation passes on GitHub
- [ ] Scheduled scan runs successfully
- [ ] PR scan runs successfully on this PR
- [ ] No permission errors in workflow execution


___

### **PR Type**
Other


___

### **Description**
- Fix OSV-Scanner workflow permissions issue

- Update OSV-Scanner action to v2.2.3

- Add required `actions: read` permission


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OSV-Scanner Workflow"] --> B["Add actions: read permission"]
  A --> C["Update to v2.2.3"]
  B --> D["Fix workflow validation error"]
  C --> E["Latest bug fixes and improvements"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>osv-scanner.yml</strong><dd><code>Fix permissions and update OSV-Scanner version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/osv-scanner.yml

<ul><li>Add <code>actions: read</code> permission to resolve workflow validation error<br> <li> Update <code>scan-scheduled</code> job from v2.2.2 to v2.2.3<br> <li> Update <code>scan-pr</code> job from v2.2.2 to v2.2.3<br> <li> Add explanatory comment for the new permission</ul>


</details>


  </td>
  <td><a href="https://github.com/MarjovanLier/SouthAfricanIDValidator/pull/36/files#diff-cffe33bb0ffb2810cb2ba28b35e9fb9ebef98fd615b71ef50305846fa8ba0e00">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

