### PR TITLE
style(code): Fix PER code style violations

### DIFF
--- a/src/SouthAfricanIDValidator.php
+++ b/src/SouthAfricanIDValidator.php
@@ -454,7 +454,7 @@ final class SouthAfricanIDValidator
      *
      * @psalm-return 'female'|'male'|null
      */
-    public static function extractGender(string $idNumber): string|null
+    public static function extractGender(string $idNumber): ?string
     {
         $sanitised = self::sanitiseNumber($idNumber);
 
@@ -482,7 +482,7 @@ final class SouthAfricanIDValidator
      *
      * @psalm-return 'permanent_resident'|'refugee'|'south_african_citizen'|null
      */
-    public static function extractCitizenship(string $idNumber): string|null
+    public static function extractCitizenship(string $idNumber): ?string
     {
         $sanitised = self::sanitiseNumber($idNumber);
 

--- a/tests/Unit/AdvancedMutationKillerTest.php
+++ b/tests/Unit/AdvancedMutationKillerTest.php
@@ -41,8 +41,8 @@ final class AdvancedMutationKillerTest extends TestCase
             self::assertFalse(
                 SouthAfricanIDValidator::isValidIDDate($problematicLength),
                 sprintf(
-                    "Input '%s' (length %d) MUST fail due to length validation at line 138. " .
-                    "If this passes, the early return was bypassed by mutation!",
+                    "Input '%s' (length %d) MUST fail due to length validation at line 138. "
+                    . "If this passes, the early return was bypassed by mutation!",
                     $problematicLength,
                     strlen($problematicLength),
                 ),
@@ -53,8 +53,8 @@ final class AdvancedMutationKillerTest extends TestCase
         // This is the most dangerous case - '1234' -> '181234' might be valid
         self::assertFalse(
             SouthAfricanIDValidator::isValidIDDate('1234'),
-            'MUTATION DETECTOR: If this passes, Line 138 mutation escaped! ' .
-            'Input "1234" should fail length check, not become valid date "181234"',
+            'MUTATION DETECTOR: If this passes, Line 138 mutation escaped! '
+            . 'Input "1234" should fail length check, not become valid date "181234"',
         );
     }
 

--- a/tests/Unit/EquivalentMutationBreakerTest.php
+++ b/tests/Unit/EquivalentMutationBreakerTest.php
@@ -168,9 +168,9 @@ final class EquivalentMutationBreakerTest extends TestCase
         self::assertLessThan(
             1.0, // 1 second threshold
             $executionTime,
-            sprintf('PERFORMANCE INDICATOR: Execution took %ss. ', $executionTime) .
-            "If significantly slow, Line 168 optimization may have been bypassed. " .
-            "Note: This may vary by system performance.",
+            sprintf('PERFORMANCE INDICATOR: Execution took %ss. ', $executionTime)
+            . "If significantly slow, Line 168 optimization may have been bypassed. "
+            . "Note: This may vary by system performance.",
         );
 
         // Strategy 2: Edge case testing

--- a/tests/Unit/EscapedMutationTargetingTest.php
+++ b/tests/Unit/EscapedMutationTargetingTest.php
@@ -225,8 +225,8 @@ final class EscapedMutationTargetingTest extends TestCase
 
             self::assertFalse(
                 SouthAfricanIDValidator::luhnIDValidate($fullId),
-                sprintf('ID %s should return false due to invalid date (%s), ', $fullId, $testCase['description']) .
-                "even though Luhn checksum is valid",
+                sprintf('ID %s should return false due to invalid date (%s), ', $fullId, $testCase['description'])
+                . "even though Luhn checksum is valid",
             );
         }
     }


### PR DESCRIPTION
## Summary

Fix nullable type declaration and operator linebreak violations identified by PER code style checker.

## Changes

- **Nullable type declarations**: Change `string|null` to `?string` for return types in:
  - `extractGender()` method
  - `extractCitizenship()` method
- **Operator linebreaks**: Fix concatenation operator placement in test files:
  - `AdvancedMutationKillerTest.php`
  - `EquivalentMutationBreakerTest.php`
  - `EscapedMutationTargetingTest.php`

## Test Plan

- [x] PER code style checker passes for all 40 files
- [x] All existing tests continue to pass